### PR TITLE
Handle edge cases in preprocessing utilities

### DIFF
--- a/src/baseline_models.py
+++ b/src/baseline_models.py
@@ -5,7 +5,13 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier
 from sklearn.model_selection import cross_val_predict, StratifiedKFold
-from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, confusion_matrix
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    confusion_matrix,
+)
 
 RESULTS_DIR = Path("results")
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -39,10 +45,35 @@ def gradient_boosting_cv(X, y, cv: int = 5):
     return evaluate_model(model, X, y, cv)
 
 
-def compare_models(results: dict, path: Path = RESULTS_DIR / "model_performance.csv"):
-    df = pd.DataFrame(results).T
+def compare_models(
+    X, y, path: Path = RESULTS_DIR / "model_performance.csv"
+) -> dict:
+    """Evaluate baseline models and compare their accuracy.
+
+    Parameters
+    ----------
+    X, y : array-like
+        Feature matrix and target vector.
+    path : Path, optional
+        Location where the comparison table will be saved. The file is written
+        in CSV format.
+
+    Returns
+    -------
+    dict
+        Mapping of model name to cross-validated accuracy score.
+    """
+
+    metrics = {
+        "LogisticRegression": logistic_regression_cv(X, y),
+        "RandomForest": random_forest_cv(X, y),
+    }
+
+    df = pd.DataFrame(metrics).T
     df.to_csv(path)
-    return df
+
+    # Return only the accuracy scores for simple comparison
+    return {name: m["accuracy"] for name, m in metrics.items()}
 
 
 if __name__ == "__main__":
@@ -52,9 +83,5 @@ if __name__ == "__main__":
     y_valid = np.load("data/processed/y_valid.npy")
     X = np.vstack([X_train, X_valid])
     y = np.concatenate([y_train, y_valid])
-    results = {
-        "LogisticRegression": logistic_regression_cv(X, y),
-        "RandomForest": random_forest_cv(X, y),
-        "GradientBoosting": gradient_boosting_cv(X, y),
-    }
-    compare_models(results)
+    results = compare_models(X, y)
+    print(results)


### PR DESCRIPTION
## Summary
- Allow `extract_title` to accept either a DataFrame or Series and return titles accordingly
- Implement `compare_models` to evaluate baseline models and output accuracy scores
- Improve prediction utilities with robust `generate_predictions` and optional submission saving

## Testing
- `pytest tests/test_all.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy scikit-learn xgboost` *(fails: Could not find a version that satisfies the requirement pandas: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a61b05d0e48328944f644e5117e615