### PR TITLE
Implement missing preprocessing steps and baseline training helpers

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -58,6 +58,18 @@ def save_data_summary(train: pd.DataFrame, test: pd.DataFrame,
         f.write(str(categorical_value_counts(test)) + "\n")
 
 
+def generate_data_summary() -> None:
+    """Generate and persist a simple textual summary of the data.
+
+    This helper is a thin wrapper used in the test-suite. It loads the raw
+    training and test sets and writes a summary file to
+    ``data/processed/data_summary.txt`` using :func:`save_data_summary`.
+    """
+
+    train, test = load_data()
+    save_data_summary(train, test)
+
+
 if __name__ == "__main__":
     train_df, test_df = load_data()
     save_data_summary(train_df, test_df)

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -12,6 +12,32 @@ from feature_engineering import engineer_features
 PROCESSED_DIR = Path("data/processed")
 
 
+def encode_categorical(df: pd.DataFrame) -> pd.DataFrame:
+    """Encode categorical columns using integer codes."""
+    df_encoded = df.copy()
+    cat_cols = df_encoded.select_dtypes(include=["object", "category"]).columns
+    for col in cat_cols:
+        df_encoded[col] = df_encoded[col].astype("category").cat.codes
+    return df_encoded
+
+
+def scale_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Scale numerical features to zero mean and unit variance."""
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(df)
+    return pd.DataFrame(scaled, columns=df.columns, index=df.index)
+
+
+def create_train_val_split(
+    X: pd.DataFrame,
+    y: pd.Series,
+    test_size: float = 0.2,
+    random_state: int = 42,
+):
+    """Split data into train and validation sets."""
+    return train_test_split(X, y, test_size=test_size, stratify=y, random_state=random_state)
+
+
 def split_data(X: pd.DataFrame, y: pd.Series, test_size: float = 0.2, random_state: int = 42):
     return train_test_split(X, y, test_size=test_size, stratify=y, random_state=random_state)
 


### PR DESCRIPTION
## Summary
- Generate a simple textual data summary for quick dataset inspection
- Expose family size and missing value utilities plus an `apply_feature_engineering` helper
- Add straightforward categorical encoding, feature scaling, and train/validation split helpers
- Provide baseline `train_logistic_regression` and `train_random_forest` routines

## Testing
- `pip install pandas numpy scikit-learn -q` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest tests/test_all.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a61b05d0e48328944f644e5117e615